### PR TITLE
add reduceResultsList.fun arg to reduceResultsBatchmark

### DIFF
--- a/R/reduceResultsBatchmark.R
+++ b/R/reduceResultsBatchmark.R
@@ -14,7 +14,7 @@
 #'
 #' @return [mlr3::BenchmarkResult].
 #' @export
-reduceResultsBatchmark = function(ids = NULL, store_backends = TRUE, reg = batchtools::getDefaultRegistry()) { # nolint
+reduceResultsBatchmark = function(ids = NULL, store_backends = TRUE, reg = batchtools::getDefaultRegistry(), reduceResultsList.fun=NULL) { # nolint
   if (is.null(ids)) {
     ids = batchtools::findDone(ids, reg = reg)
   } else {
@@ -61,7 +61,7 @@ reduceResultsBatchmark = function(ids = NULL, store_backends = TRUE, reg = batch
       learner = get_export(needle, reg)
     }
 
-    results = batchtools::reduceResultsList(tab$job.id, reg = reg)
+    results = batchtools::reduceResultsList(tab$job.id, reg = reg, fun=reduceResultsList.fun)
 
     if (!version_checked) {
       version_checked = TRUE


### PR DESCRIPTION
Hi! in my use case, I want to do model interpretation, so I am using store_models=TRUE. 
But that makes my cluster system kill my R process (too much RAM used) when I do reduceResultsBatchmark, which gets killed when it calls reduceResultsList, https://github.com/mlr-org/mlr3batchmark/issues/18#issuecomment-1944406466 because the total of all `learner_state` is too large.
So in this PR I add a new argument, reduceResultsList.fun, which gets passed on, so then I can process the `learner_state`. For example the code below works for me using this PR. (uses reasonable amount of memory / R is not killed)
```r
ignore.learner <- function(L){
  L$learner_state$model <- NULL
  L
}
bmr = mlr3batchmark::reduceResultsBatchmark(ids, reg = reg, store_backends = FALSE, reduceResultsList.fun=ignore.learner)
```
(but without the proposed reduceResultsList.fun, the above code results in my cluster system killing R)
Thanks for your consideration.