### PR TITLE
chore: fix typos and populate cspell dictionary

### DIFF
--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -1,2 +1,36 @@
 # Project-specific words — commit and share with the team.
 # Add words here (or via "Add to project dictionary" in VS Code / Cursor).
+autotest
+batchmark
+batchtools
+bibentries
+Classif
+CRAN
+Hyperparameters
+integerish
+lockfiles
+lrns
+msrs
+multiarch
+nolint
+ORCID
+paramtest
+pkgdown
+redocument
+Regr
+renv
+repls
+resamplings
+robustify
+roxygen
+rpart
+Rscript
+Rtmp
+rsmp
+rsmps
+tdhock
+testthat
+tgen
+tgens
+tsks
+yolobox

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ reg = makeExperimentRegistry(NA)
 
     ## No readable configuration file found
 
-    ## Created registry in '/tmp/RtmpbcuMc4/registry27b8961304f5da' using cluster functions 'Interactive'
+    ## Created registry in '/tmp/Rtmpqi04ir/registry12bb56a23ce1' using cluster functions 'Interactive'
 
 ``` r
 ids = batchmark(design, reg = reg)
@@ -56,11 +56,11 @@ ids = batchmark(design, reg = reg)
 
     ## Adding problem 'abc694dd29a7a8ce'
 
-    ## Exporting new objects: '2da7eeb80b94fc3b' ...
+    ## Exporting new objects: '10ee41ae832e9304' ...
 
-    ## Exporting new objects: 'c905990877a775af' ...
+    ## Exporting new objects: 'c555f9dfec9c1e4f' ...
 
-    ## Exporting new objects: '3acc41a799a260d8' ...
+    ## Exporting new objects: '02253ecc9afd614a' ...
 
     ## Exporting new objects: 'ecf8ee265ec56766' ...
 
@@ -70,7 +70,7 @@ ids = batchmark(design, reg = reg)
 
     ## Adding problem 'f9791e97f9813150'
 
-    ## Exporting new objects: '62ac3bb85aabfbaf' ...
+    ## Exporting new objects: 'd9b697eed2a7335a' ...
 
     ## Adding 6 experiments ('f9791e97f9813150'[1] x 'run_learner'[2] x repls[3]) ...
 
@@ -80,42 +80,17 @@ submitJobs()
 
     ## Submitting 12 jobs in 12 chunks using cluster functions 'Interactive' ...
 
-    ## Error in workhorse(iteration = job$repl, task = data, learner = learner,  : 
-    ##   unused argument (lgr_threshold = lgr::get_logger("mlr3")$threshold)
-    ## Error in workhorse(iteration = job$repl, task = data, learner = learner,  : 
-    ##   unused argument (lgr_threshold = lgr::get_logger("mlr3")$threshold)
-    ## Error in workhorse(iteration = job$repl, task = data, learner = learner,  : 
-    ##   unused argument (lgr_threshold = lgr::get_logger("mlr3")$threshold)
-    ## Error in workhorse(iteration = job$repl, task = data, learner = learner,  : 
-    ##   unused argument (lgr_threshold = lgr::get_logger("mlr3")$threshold)
-    ## Error in workhorse(iteration = job$repl, task = data, learner = learner,  : 
-    ##   unused argument (lgr_threshold = lgr::get_logger("mlr3")$threshold)
-    ## Error in workhorse(iteration = job$repl, task = data, learner = learner,  : 
-    ##   unused argument (lgr_threshold = lgr::get_logger("mlr3")$threshold)
-    ## Error in workhorse(iteration = job$repl, task = data, learner = learner,  : 
-    ##   unused argument (lgr_threshold = lgr::get_logger("mlr3")$threshold)
-    ## Error in workhorse(iteration = job$repl, task = data, learner = learner,  : 
-    ##   unused argument (lgr_threshold = lgr::get_logger("mlr3")$threshold)
-    ## Error in workhorse(iteration = job$repl, task = data, learner = learner,  : 
-    ##   unused argument (lgr_threshold = lgr::get_logger("mlr3")$threshold)
-    ## Error in workhorse(iteration = job$repl, task = data, learner = learner,  : 
-    ##   unused argument (lgr_threshold = lgr::get_logger("mlr3")$threshold)
-    ## Error in workhorse(iteration = job$repl, task = data, learner = learner,  : 
-    ##   unused argument (lgr_threshold = lgr::get_logger("mlr3")$threshold)
-    ## Error in workhorse(iteration = job$repl, task = data, learner = learner,  : 
-    ##   unused argument (lgr_threshold = lgr::get_logger("mlr3")$threshold)
-
 ``` r
 getStatus()
 ```
 
-    ## Status for 12 jobs at 2025-05-26 09:23:22:
+    ## Status for 12 jobs at 2026-06-11 11:59:26:
     ##   Submitted    : 12 (100.0%)
     ##   -- Queued    :  0 (  0.0%)
     ##   -- Started   : 12 (100.0%)
     ##   ---- Running :  0 (  0.0%)
-    ##   ---- Done    :  0 (  0.0%)
-    ##   ---- Error   : 12 (100.0%)
+    ##   ---- Done    : 12 (100.0%)
+    ##   ---- Error   :  0 (  0.0%)
     ##   ---- Expired :  0 (  0.0%)
 
 ``` r
@@ -123,7 +98,12 @@ reduceResultsBatchmark()
 ```
 
     ## 
-    ## ── <BenchmarkResult> of 0 rows with 0 resampling run ───────────────────────────
+    ## ── <BenchmarkResult> of 12 rows with 4 resampling run ──────────────────────────
+    ##  nr task_id          learner_id resampling_id iters warnings errors
+    ##   1    iris classif.featureless            cv     3        0      0
+    ##   2    iris       classif.rpart            cv     3        0      0
+    ##   3   sonar classif.featureless            cv     3        0      0
+    ##   4   sonar       classif.rpart            cv     3        0      0
 
 ## Resources
 

--- a/cspell.json
+++ b/cspell.json
@@ -14,6 +14,10 @@
     "man/",   // generated man pages
     "renv/"   // renv library
   ],
+  // ignore non-deterministic tokens in generated chunk output
+  "ignoreRegExpList": [
+    "/Rtmp[A-Za-z0-9]+/g" // random temp-directory names in README output
+  ],
   // use cspell R-dictionary + project-specific word list
   "dictionaries": ["r", "project-words"],
   "dictionaryDefinitions": [

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -5,7 +5,7 @@ Mattermost
 ORCID
 ResampleResult
 StackOverflow
-analyse
+analyze
 batchmark
 batchtools
 cmd


### PR DESCRIPTION
Spellcheck pass using cspell. The dictionary now lives in `.cspell/project-words.txt` and cspell exits clean.

## Typos fixed
- `inst/WORDLIST`: `analyse` → `analyze` (British → en-US)

## Generated files
- `README.md` regenerated from `README.Rmd` via `devtools::build_readme()`. This also refreshed stale chunk output (the previously committed output showed `workhorse(...)` errors and 0 results; the rebuilt output runs successfully). Note: `devtools::build_readme()` succeeded but warned that two dependencies are out of date (mlr3 1.6.0 vs 1.7.0, mlr3misc 0.21.0 vs 0.22.0).

## cspell config
- Added an `ignoreRegExpList` entry `/Rtmp[A-Za-z0-9]+/g` so non-deterministic temp-directory names in the README's generated output do not trip cspell on each rebuild.

## Words added to .cspell/project-words.txt
autotest, batchmark, batchtools, bibentries, Classif, CRAN, Hyperparameters, integerish, lockfiles, lrns, msrs, multiarch, nolint, ORCID, paramtest, pkgdown, redocument, Regr, renv, repls, resamplings, robustify, roxygen, rpart, Rscript, Rtmp, rsmp, rsmps, tdhock, testthat, tgen, tgens, tsks, yolobox

🤖 Generated with [Claude Code](https://claude.com/claude-code)