### PR TITLE
docs: redocument with roxygen2 8.0.0.9000

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,4 +32,4 @@ Suggests:
     testthat
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+Config/roxygen2/version: 8.0.0.9000

--- a/man/batchmark.Rd
+++ b/man/batchmark.Rd
@@ -24,7 +24,7 @@ Store the fitted model in the resulting object=
 Set to \code{TRUE} if you want to further analyse the models or want to
 extract information like variable importance.}
 
-\item{reg}{\link[batchtools:makeExperimentRegistry]{batchtools::ExperimentRegistry}.}
+\item{reg}{\link[batchtools:ExperimentRegistry]{batchtools::ExperimentRegistry}.}
 
 \item{renv_project}{\code{character(1)}\cr
 Path to a renv project.
@@ -38,9 +38,9 @@ This function provides the functionality to leave the interface of \CRANpkg{mlr3
 of benchmark experiments and switch over to \CRANpkg{batchtools} for a more fine grained control over
 the execution.
 
-\code{batchmark()} populates a \link[batchtools:makeExperimentRegistry]{batchtools::ExperimentRegistry} with jobs in a \code{\link[mlr3:benchmark]{mlr3::benchmark()}} fashion.
-Each combination of \link[mlr3:Task]{mlr3::Task} and \link[mlr3:Resampling]{mlr3::Resampling} defines a \link[batchtools:addProblem]{batchtools::Problem},
-each \link[mlr3:Learner]{mlr3::Learner} is an \link[batchtools:addAlgorithm]{batchtools::Algorithm}.
+\code{batchmark()} populates a \link[batchtools:ExperimentRegistry]{batchtools::ExperimentRegistry} with jobs in a \code{\link[mlr3:benchmark]{mlr3::benchmark()}} fashion.
+Each combination of \link[mlr3:Task]{mlr3::Task} and \link[mlr3:Resampling]{mlr3::Resampling} defines a \link[batchtools:Problem]{batchtools::Problem},
+each \link[mlr3:Learner]{mlr3::Learner} is an \link[batchtools:Algorithm]{batchtools::Algorithm}.
 
 After the jobs have been submitted and are terminated, results can be collected with \code{\link[=reduceResultsBatchmark]{reduceResultsBatchmark()}}
 which returns a \link[mlr3:BenchmarkResult]{mlr3::BenchmarkResult} and thus to return to the interface of \CRANpkg{mlr3}.

--- a/man/mlr3batchmark-package.Rd
+++ b/man/mlr3batchmark-package.Rd
@@ -22,6 +22,7 @@ Useful links:
 
 Authors:
 \itemize{
+  \item Marc Becker \email{marcbecker@posteo.de} (\href{https://orcid.org/0000-0002-8115-0400}{ORCID})
   \item Michel Lang \email{michellang@gmail.com} (\href{https://orcid.org/0000-0001-9754-0393}{ORCID})
 }
 

--- a/man/reduceResultsBatchmark.Rd
+++ b/man/reduceResultsBatchmark.Rd
@@ -47,7 +47,7 @@ If \code{FALSE}, all learners (that need marshaling) are stored in marshaled for
 \description{
 Collect the results from jobs defined via \code{\link[=batchmark]{batchmark()}} and combine them into a \link[mlr3:BenchmarkResult]{mlr3::BenchmarkResult}.
 
-Note that \code{ids} defaults to finished jobs (as reported by \code{\link[batchtools:findJobs]{batchtools::findDone()}}).
+Note that \code{ids} defaults to finished jobs (as reported by \code{\link[batchtools:findDone]{batchtools::findDone()}}).
 If a job threw an error, is expired or is still running, it will be ignored with this default.
 Just leaving these jobs out in an analysis is \strong{not} statistically sound.
 Instead, try to robustify your jobs by using a fallback learner (c.f. \link[mlr3:Learner]{mlr3::Learner}).


### PR DESCRIPTION
Regenerate man pages and NAMESPACE with `devtools::document()` using roxygen2 8.0.0.9000.

🤖 Generated with [Claude Code](https://claude.com/claude-code)